### PR TITLE
special float json encoding decoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/nautiluslabsco/null
+
+go 1.12
+
+require (
+	github.com/json-iterator/go v1.1.7
+	github.com/modern-go/reflect2 v1.0.1
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
+github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
+github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/json.go
+++ b/json.go
@@ -1,0 +1,101 @@
+package null
+
+import (
+	"math"
+	"reflect"
+	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
+)
+
+func JSONFloatEncoderExtension() jsoniter.Extension {
+	return jsoniter.EncoderExtension(map[reflect2.Type]jsoniter.ValEncoder{
+		reflect2.DefaultTypeOfKind(reflect.Float64): floatEncDec{},
+		reflect2.TypeByName("null.Float"):           nullFloatEncDec{},
+	})
+}
+
+func JSONFloatDecoderExtension() jsoniter.Extension {
+	return jsoniter.DecoderExtension(map[reflect2.Type]jsoniter.ValDecoder{
+		reflect2.DefaultTypeOfKind(reflect.Float64): floatEncDec{},
+		reflect2.TypeByName("null.Float"):           nullFloatEncDec{},
+	})
+}
+
+func decode(iter *jsoniter.Iterator) Float {
+	valueType := iter.WhatIsNext()
+	switch valueType {
+	case jsoniter.NilValue:
+		iter.ReadNil()
+		return Float{}
+	case jsoniter.NumberValue:
+		return FloatFrom(iter.ReadFloat64())
+	case jsoniter.StringValue:
+		switch str := iter.ReadString(); str {
+		case "+Inf":
+			return FloatFrom(math.Inf(+1))
+		case "-Inf":
+			return FloatFrom(math.Inf(-1))
+		case "NaN":
+			return FloatFrom(math.NaN())
+		default:
+			iter.ReportError("fuzzyFloat64Decoder", "not number \"NaN\", \"+Inf\", or \"-Inf\"")
+		}
+	default:
+		iter.ReportError("fuzzyFloat64Decoder", "not number or string")
+	}
+	return Float{}
+}
+
+func encode(val Float, stream *jsoniter.Stream) {
+	if val.Valid {
+		fval := val.Float64
+		if math.IsNaN(fval) {
+			stream.WriteString("NaN")
+		} else if math.IsInf(fval, 1) {
+			stream.WriteString("+Inf")
+		} else if math.IsInf(fval, -1) {
+			stream.WriteString("-Inf")
+		} else {
+			stream.WriteFloat64(fval)
+		}
+	} else {
+		stream.WriteNil()
+	}
+
+}
+
+type nullFloatEncDec struct {
+}
+
+func (e nullFloatEncDec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	val := *((*Float)(ptr))
+	encode(val, stream)
+}
+
+func (e nullFloatEncDec) IsEmpty(ptr unsafe.Pointer) bool {
+	return false
+}
+
+func (d nullFloatEncDec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	val := decode(iter)
+	*((*Float)(ptr)) = val
+}
+
+type floatEncDec struct {
+}
+
+func (e floatEncDec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	fval := *((*float64)(ptr))
+	encode(FloatFrom(fval), stream)
+}
+
+func (e floatEncDec) IsEmpty(ptr unsafe.Pointer) bool {
+	return false
+}
+
+func (d floatEncDec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	val := decode(iter)
+	*((*float64)(ptr)) = val.Float64
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,64 @@
+package null
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+)
+
+type floatData struct {
+	Float            float64
+	FloatNaN         float64
+	FloatPtr         *float64
+	FloatPtrNaN      *float64
+	FloatPtrNil      *float64
+	NullFloat        Float
+	NullFloatNaN     Float
+	NullFloatInf     Float
+	NullFloatInvalid Float
+}
+
+func TestJSONEncodeDecode(t *testing.T) {
+	json := jsoniter.Config{
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+	}.Froze()
+	json.RegisterExtension(JSONFloatDecoderExtension())
+	json.RegisterExtension(JSONFloatEncoderExtension())
+
+	data := floatData{
+		10.0,
+		math.NaN(),
+		FloatFrom(11.0).Ptr(),
+		FloatFrom(math.NaN()).Ptr(),
+		nil,
+		FloatFrom(10.0),
+		FloatFrom(math.NaN()),
+		FloatFrom(math.Inf(1)),
+		Float{},
+	}
+	bs, err := json.Marshal(data)
+	assert.NoError(t, err)
+
+	var decodedData floatData
+	err = json.Unmarshal(bs, &decodedData)
+	assert.NoError(t, err)
+
+	assert.Equal(t, math.IsNaN(*decodedData.FloatPtrNaN), math.IsNaN(*data.FloatPtrNaN))
+	decodedData.FloatPtrNaN = nil
+	data.FloatPtrNaN = nil
+
+	assert.Equal(t, math.IsNaN(decodedData.NullFloatNaN.Float64), math.IsNaN(data.NullFloatNaN.Float64))
+	decodedData.NullFloatNaN = Float{}
+	data.NullFloatNaN = Float{}
+
+	assert.Equal(t, math.IsNaN(decodedData.NullFloatNaN.Float64), math.IsNaN(data.NullFloatNaN.Float64))
+	decodedData.FloatNaN = 0
+	data.FloatNaN = 0
+
+	assert.True(t, reflect.DeepEqual(decodedData, data))
+}


### PR DESCRIPTION
Right now our floats are encoded in json. JSON doesn't support NaN or Inf floats - but does support null. 

This encoding decoding handles NaN and Inf by writing strings.

Presently we already encode our floats as null | number, so this is less dramatic of a change than number -> number | ... 

Part  of the core motivator here is an inability to encode NaNs without specially rewriting them. 